### PR TITLE
Book Waitlist Update

### DIFF
--- a/server/graphql/schema/index.js
+++ b/server/graphql/schema/index.js
@@ -9,6 +9,7 @@ module.exports = buildSchema(`
     location: Location
     owns: [Ownership!]
     checkedOut: [Ownership!]
+    waitlisted: [Ownership!]
   }
 
   type Location {
@@ -37,6 +38,7 @@ module.exports = buildSchema(`
     book: Book!
     isAvailable: Boolean!
     checkoutData: [Checkout!]
+    waitlist: [User!]
   }
 
   type Checkout {
@@ -79,6 +81,8 @@ module.exports = buildSchema(`
     checkoutBook(ownershipId: ID!, checkoutDate: String!, dueDate: String!): Ownership!
     returnBook(ownershipId: ID!, returnDate: String!, condition: String): Ownership!
     removeBook(ownershipId: ID!): Boolean!
+    joinWaitlist(ownershipId: ID!): Ownership!
+    leaveWaitlist(ownershipId: ID!): Ownership!
   }
 
   schema {

--- a/server/models/ownership.js
+++ b/server/models/ownership.js
@@ -46,6 +46,12 @@ const ownershipSchema = new Schema({
     validate: (v) => Array.isArray(v),
     required: false,
   },
+  waitlist: {
+    type: [Schema.Types.ObjectId],
+    ref: "User",
+    validate: (v) => Array.isArray(v),
+    required: false,
+  },
 });
 
 module.exports = mongoose.model("Ownership", ownershipSchema);

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -27,6 +27,12 @@ const userSchema = new Schema({
     validate: (v) => Array.isArray(v),
     required: false,
   },
+  waitlisted: {
+    type: [Schema.Types.ObjectId],
+    ref: "Ownership",
+    validate: (v) => Array.isArray(v),
+    required: false,
+  },
   location: {
     country: {
       type: String,


### PR DESCRIPTION
Resolvers added:

```
    joinWaitlist(ownershipId: ID!): Ownership!
    leaveWaitlist(ownershipId: ID!): Ownership!
```

GraphQL Type definitions updated (and mongo models updated to match):
```
  type User {
    ...
    waitlisted: [Ownership!]
  }
  type Ownership {
    ...
    waitlist: [User!]
  }
```

- `removeBook` will now check if there is a waitlist for a given book. If it finds there is, it will loop through each user in the waitlist and delete the reference to that ownership object.
- Since `removeBook` was also checking if a book is first available before conducting a removal, it did not catch the case where a book was unavailable and not checked out due to an existing waitlist. removeBook has been updated to catch this case.
- `returnBook` will keep a ownership's isAvailable false if there is a waitlist and if a book is returned already, it will throw an error
- `leaveWaitlist` will set an ownership's isAvailable to true if the book no longer has anyone on the waitlist and the book isn't currently checked out and the availability is false due to waiting for someone on the waitlist.

- Dataloader functions have been added to accomodate waitlist data