### PR TITLE
getUser query added

### DIFF
--- a/server/graphql/resolvers/book.js
+++ b/server/graphql/resolvers/book.js
@@ -19,11 +19,15 @@ module.exports = {
     }
   },
   getBookById: async ({ bookId }) => {
-    const book = await Book.findById(bookId);
-    if (!book) {
-      throw new Error("Cannot find a Book by that ID!");
+    try {
+      const book = await Book.findById(bookId);
+      if (!book) {
+        throw new Error("Cannot find a Book by that ID!");
+      }
+      return transformBook(book);
+    } catch (err) {
+      throw err;
     }
-    return transformBook(book);
   },
   addBook: async (
     {
@@ -41,6 +45,9 @@ module.exports = {
     req
   ) => {
     if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
       throw new Error("Authentication required!");
     }
 
@@ -86,6 +93,9 @@ module.exports = {
   },
   getInventory: async (args, req) => {
     if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
       throw new Error("Authentication required!");
     }
 

--- a/server/graphql/resolvers/ownership.js
+++ b/server/graphql/resolvers/ownership.js
@@ -1,12 +1,14 @@
 const Book = require("../../models/book");
 const User = require("../../models/user");
 const Ownership = require("../../models/ownership");
-const { transformBook, transformOwner } = require("./merge");
-const { renderGraphiQL } = require("express-graphql/renderGraphiQL");
+const { transformOwner } = require("./merge");
 
 module.exports = {
   checkoutBook: async ({ ownershipId, checkoutDate, dueDate }, req) => {
     if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
       throw new Error("Authentication required!");
     }
 
@@ -54,6 +56,9 @@ module.exports = {
   },
   returnBook: async ({ ownershipId, returnDate, condition }, req) => {
     if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
       throw new Error("Authentication required!");
     }
 
@@ -106,6 +111,9 @@ module.exports = {
   },
   removeBook: async ({ ownershipId }, req) => {
     if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
       throw new Error("Authentication required!");
     }
 
@@ -187,6 +195,9 @@ module.exports = {
   },
   joinWaitlist: async ({ ownershipId }, req) => {
     if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
       throw new Error("Authentication required!");
     }
 
@@ -236,6 +247,9 @@ module.exports = {
   },
   leaveWaitlist: async ({ ownershipId }, req) => {
     if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
       throw new Error("Authentication required!");
     }
 

--- a/server/graphql/resolvers/ownership.js
+++ b/server/graphql/resolvers/ownership.js
@@ -63,6 +63,9 @@ module.exports = {
     }
 
     try {
+      if (!returnDate || returnDate === "") {
+        throw new Error("A returnDate is required to return a book");
+      }
       const ownership = await Ownership.findById(ownershipId);
       if (!ownership) {
         throw new Error("Cannot find an Ownership with the given ID");

--- a/server/graphql/resolvers/user.js
+++ b/server/graphql/resolvers/user.js
@@ -6,35 +6,39 @@ const { transformUser } = require("./merge");
 
 module.exports = {
   login: async ({ email, password }) => {
-    email = email.toLowerCase();
+    try {
+      email = email.toLowerCase();
 
-    // Check if email exists
-    const user = await User.findOne({ email });
-    if (!user) {
-      throw new Error("The email or password entered is incorrect");
-    }
-
-    // Check if password matches
-    const match = await bcrypt.compare(password, user.password);
-    if (!match) {
-      throw new Error("The email or password entered is incorrect");
-    }
-
-    const token = jwt.sign(
-      { userId: user._id, email },
-      process.env.AUTH_SECRET,
-      {
-        expiresIn: "1h",
+      // Check if email exists
+      const user = await User.findOne({ email });
+      if (!user) {
+        throw new Error("The email or password entered is incorrect");
       }
-    );
 
-    return {
-      token,
-      tokenExpiration: 1,
-      userId: user._id,
-      email,
-      displayName: user.displayName,
-    };
+      // Check if password matches
+      const match = await bcrypt.compare(password, user.password);
+      if (!match) {
+        throw new Error("The email or password entered is incorrect");
+      }
+
+      const token = jwt.sign(
+        { userId: user._id, email },
+        process.env.AUTH_SECRET,
+        {
+          expiresIn: "1h",
+        }
+      );
+
+      return {
+        token,
+        tokenExpiration: 1,
+        userId: user._id,
+        email,
+        displayName: user.displayName,
+      };
+    } catch (err) {
+      throw err;
+    }
   },
   createAccount: async ({ email, displayName, password, confirmPassword }) => {
     try {

--- a/server/graphql/resolvers/user.js
+++ b/server/graphql/resolvers/user.js
@@ -2,6 +2,7 @@ const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 
 const User = require("../../models/user");
+const { transformUser } = require("./merge");
 
 module.exports = {
   login: async ({ email, password }) => {
@@ -77,6 +78,25 @@ module.exports = {
           displayName,
         };
       }
+    } catch (err) {
+      throw err;
+    }
+  },
+  getUser: async (args, req) => {
+    if (!req.isAuth) {
+      if (req.error) {
+        throw new Error(req.error);
+      }
+      throw new Error("Authentication required!");
+    }
+
+    try {
+      const user = await User.findById(req.userId);
+      if (!user) {
+        throw new Error("Cannot find a user with hte requester's userId");
+      }
+
+      return transformUser(user);
     } catch (err) {
       throw err;
     }

--- a/server/graphql/schema/index.js
+++ b/server/graphql/schema/index.js
@@ -72,6 +72,7 @@ module.exports = buildSchema(`
     books(query: String): [Book!]
     getInventory: [Ownership!]
     getBookById(bookId: ID!): Book!
+    getUser: User!
   }
 
   type RootMutation {

--- a/server/middleware/is-auth.js
+++ b/server/middleware/is-auth.js
@@ -18,9 +18,11 @@ module.exports = (req, res, next) => {
   try {
     decodedToken = jwt.verify(token, process.env.AUTH_SECRET);
   } catch (err) {
-    res.statusMessage = "Unauthorized: jwt expired";
-    res.status(401).end();
-    return;
+    req.isAuth = false;
+    if (err.name === "TokenExpiredError") {
+      req.error = `${err.name}: ${err.message}`;
+    }
+    return next();
   }
 
   // valid, verified token


### PR DESCRIPTION
1. Added a `getUser` query which doesn't take any arguments and returns all user data when authenticated.
2. Removed 401 status code when JWT is expired. Readded the previous error.
3. Moved some resolver logic into try-catch. I learned that thrown errors in resolvers outside of a try-catch will cause a 500 status code, whereas when caught inside a try-catch cause a 400 status code.
4. Added a returnDate check when returning a book. Now the query will not accept an empty string.