### PR TITLE
DataLoader fix for loading fetching waitlist data

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -26,6 +26,7 @@
         "customValidators": "customValidator"
       }
     ],
-    "no-unused-vars": "warn"
+    "no-unused-vars": "warn",
+    "react-hooks/exhaustive-deps": 0
   }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -47,6 +47,7 @@ function App() {
   };
 
   const logout = () => {
+    setQuery("");
     localStorage.removeItem("email");
     localStorage.removeItem("token");
     localStorage.removeItem("displayName");

--- a/client/src/screens/LoginPage.js
+++ b/client/src/screens/LoginPage.js
@@ -106,7 +106,7 @@ export default function LoginPage() {
   // Snackbar function
   const [alert, setAlert] = useState({
     open: auth.tokenExpired,
-    message: auth.tokenExpired ? "Token Expired: Please Relog" : "",
+    message: auth.tokenExpired ? "Token Expired: Please Log In Again." : "",
   });
 
   useEffect(() => {

--- a/server/graphql/resolvers/ownership.js
+++ b/server/graphql/resolvers/ownership.js
@@ -322,4 +322,32 @@ module.exports = {
       throw err;
     }
   },
+  // Function to fix null array data points in user/ownership
+  // normalizeData: async () => {
+  //   try {
+  //     const users = await User.find();
+  //     users.forEach(async (user, i) => {
+  //       if (!user.waitlisted || user.waitlisted.length === 0) {
+  //         user.waitlisted = [];
+  //       }
+  //       if (!user.checkedOut || user.checkedOut.length === 0) {
+  //         user.checkedOut = [];
+  //       }
+  //       await user.save();
+  //     });
+
+  //     const ownerships = await Ownership.find();
+  //     ownerships.forEach(async (ownership, i) => {
+  //       if (!ownership.waitlist || ownership.waitlist.length === 0) {
+  //         ownership.waitlist = [];
+  //       }
+  //       if (!ownership.checkoutData || ownership.checkoutData.length === 0) {
+  //         ownership.checkoutData = [];
+  //       }
+  //       await ownership.save();
+  //     });
+  //   } catch (err) {
+  //     throw err;
+  //   }
+  // },
 };


### PR DESCRIPTION
Not 100% sure if this is the fix, but it seems to have solved the previous base case of:

When 1 user joins 2 waitlists for 2 copies of the same book. As in 2 different ownership.waitlist but each reference the same book.

Need to test out if this kind of bug happens for checked out items also